### PR TITLE
Feat: EPT 807 hint text

### DIFF
--- a/assets/scss/components/_map-search.scss
+++ b/assets/scss/components/_map-search.scss
@@ -2,6 +2,9 @@
   margin-top: 20px;
   background: #F3F2F1;
   & .map-search__form-actions {
-    margin-top: 156px;
+    margin-top: 220px;
+    & .govuk-button-group {
+      margin-bottom: 0;
+    } 
   }
 }

--- a/server/controllers/cases/cases-location.locale.json
+++ b/server/controllers/cases/cases-location.locale.json
@@ -1,0 +1,31 @@
+{
+  "title": "Location activity",
+  "map": {
+    "ariaLabel": "Interactive map",
+    "instructions": "Use arrow keys to pan, plus and minus to zoom."
+  },
+  "overlay": {
+    "point": "Point",
+    "accuracy": "Accuracy",
+    "dateTime": "Date / time",
+    "latLng": "Lat / Lng"
+  },
+  "links": {
+    "mapHelp": "Guide to the map"
+  },
+  "search": {
+    "errorSummaryTitle": "There is a problem",
+    "heading": "Search map by date and time",
+    "crn": "CRN",
+    "dateFrom": "Date from",
+    "timeFrom": "Time from",
+    "dateTo": "Date to",
+    "timeTo": "Time to",
+    "update": "Update map",
+    "clear": "Clear filters"
+  },
+  "alerts": {
+    "fetchError": "Unable to fetch location data. Please try again later.",
+    "noResults": "No location data found for the selected date range."
+  }
+}

--- a/server/controllers/cases/casesController.test.ts
+++ b/server/controllers/cases/casesController.test.ts
@@ -13,6 +13,7 @@ import {
   buildLocationPageWithServiceError,
   buildLocationPageWithValidationErrors,
 } from '../../testutils/factories/locationPage.factory'
+import casesLocationLocale from './cases-location.locale.json'
 
 jest.mock('../../services/auditService')
 jest.mock('../../services/caseLocationActivityService')
@@ -125,7 +126,11 @@ describe('CasesController', () => {
       })
       expect(res.render).toHaveBeenCalledWith(
         'pages/casesLocation',
-        buildLocationPageInitialState('X172591', { popData: mockPopDetails, currentUrl: mockCurrentUrl }),
+        buildLocationPageInitialState('X172591', {
+          locale: casesLocationLocale,
+          popData: mockPopDetails,
+          currentUrl: mockCurrentUrl,
+        }),
       )
     })
 
@@ -139,6 +144,7 @@ describe('CasesController', () => {
       expect(res.render).toHaveBeenCalledWith(
         'pages/casesLocation',
         buildLocationPageWithValidationErrors(validationErrors, mockQueryData.crn, {
+          locale: casesLocationLocale,
           popData: mockPopDetails,
           currentUrl: mockCurrentUrl,
         }),
@@ -151,8 +157,9 @@ describe('CasesController', () => {
       expect(res.render).toHaveBeenCalledWith(
         'pages/casesLocation',
         buildLocationPageWithValidationErrors([], mockQueryData.crn, {
+          locale: casesLocationLocale,
           popData: mockPopDetails,
-          locationAlert: { text: 'No location data found for the selected date range.' },
+          locationAlert: { text: casesLocationLocale.alerts.noResults },
           currentUrl: mockCurrentUrl,
         }),
       )
@@ -164,6 +171,7 @@ describe('CasesController', () => {
       expect(res.render).toHaveBeenCalledWith(
         'pages/casesLocation',
         buildLocationPageWithServiceError(mockQueryData.crn, mockQueryData.start.date, mockQueryData.end.date, {
+          locale: casesLocationLocale,
           popData: mockPopDetails,
           currentUrl: mockCurrentUrl,
         }),

--- a/server/controllers/cases/casesController.ts
+++ b/server/controllers/cases/casesController.ts
@@ -14,6 +14,7 @@ import { searchLocationsQuerySchema } from '../../schemas/locationActivity/searc
 import { getDateComponents, parseDateTimeFromISOString } from '../../utils/date'
 import { ValidationResult } from '../../models/ValidationResult'
 import { convertZodErrorToValidationError } from '../../utils/errors'
+import casesLocationLocale from './cases-location.locale.json'
 
 interface LocationDateFilterFormData {
   date: string
@@ -243,7 +244,7 @@ export default class CasesController {
           } catch (error) {
             /* eslint no-console: ["error", { allow: ["warn", "error"] }] */
             console.error('Error fetching locations:', error)
-            locationAlert = { text: 'Unable to fetch location data. Please try again later.' }
+            locationAlert = { text: casesLocationLocale.alerts.fetchError }
           }
         } else {
           validationErrors = validation.errors || []
@@ -255,11 +256,12 @@ export default class CasesController {
       formValues = this.buildDateFilterFormValues(sessionFormData, queryRange)
     }
     if (!locationAlert && hasSearched && positions.length === 0) {
-      locationAlert = { text: 'No location data found for the selected date range.' }
+      locationAlert = { text: casesLocationLocale.alerts.noResults }
     }
     res.render('pages/casesLocation', {
       activeNav: 'Location activity',
       activeTab: 'location-activity',
+      locale: casesLocationLocale,
       popData: mockPopDetails,
       positions: positionCardData,
       showComplianceBadge: true,

--- a/server/testutils/factories/locationPage.factory.ts
+++ b/server/testutils/factories/locationPage.factory.ts
@@ -56,6 +56,7 @@ export interface LocationPageRenderData {
   activeTab: string
   alert: boolean
   dateFilterForm: DateFilterForm
+  locale?: Record<string, unknown>
   fromDate: string
   hasSearched: boolean
   id: string | undefined

--- a/server/views/components/date-time-picker/template.njk
+++ b/server/views/components/date-time-picker/template.njk
@@ -37,7 +37,10 @@
                     classes: "govuk-label--s govuk-margin-bottom-2"
                 },
                 errorMessage: { text: dateErrorMessage } if dateErrorMessage,
-                value: params.value
+                value: params.value,
+                hint: {
+                    text: "For example, 17/5/2024"
+                }
             }) }}
         </fieldset>
     </div>
@@ -69,7 +72,10 @@
                     value: params.minute,
                     attributes: { "data-qa": params.id + "-minute" }
                 }
-            ]
+            ],
+            hint: {
+                text: "For example, 14:55"
+            }
         }) }}
     {% endif %}
 </div>

--- a/server/views/pages/casesLocation.njk
+++ b/server/views/pages/casesLocation.njk
@@ -24,7 +24,7 @@
   {% include "partials/popAlert.njk" %}
   {% include "partials/casesSubNavigation.njk" %}
   <div class="location-activity">
-    <h2 class="govuk-heading-m">Location activity</h2>
+    <h2 class="govuk-heading-m">{{ locale.title }}</h2>
     <div class="date-time-picker">
       <div class="govuk-grid-row">
         {% include "partials/mapSearchForm.njk" %}
@@ -33,11 +33,11 @@
     <div class="em-map" 
         data-qa="em-map" 
         role="region" 
-        aria-label="Interactive map" aria-describedby="map-instructions"
+        aria-label="{{ locale.map.ariaLabel }}" aria-describedby="map-instructions"
         tabindex="0">
 
         <span id="map-instructions" class="govuk-visually-hidden">
-          Use arrow keys to pan, plus and minus to zoom.
+          {{ locale.map.instructions }}
         </span>
         <div id="map-pan-announce" aria-live="polite" aria-atomic="true" class="govuk-visually-hidden"></div>
         <div id="map-rotation-status" aria-live="polite" aria-atomic="true" class="govuk-visually-hidden"></div>
@@ -58,20 +58,20 @@
 
        {% raw %}
   <template id="overlay-title-mdss-location">
-    <div><strong>Point {{ displayPointNumber }}</strong></div>
+    <div><strong>{{ locale.overlay.point }} {{ displayPointNumber }}</strong></div>
   </template>
 
   <template id="overlay-body-mdss-location">
     <div class="app-map__overlay-row">
-      <span class="app-map__overlay-label">Accuracy</span>
+      <span class="app-map__overlay-label">{{ locale.overlay.accuracy }}</span>
       <span class="app-map__overlay-value">{{ displayAccuracy }}</span>
     </div>
     <div class="app-map__overlay-row">
-      <span class="app-map__overlay-label">Date / time</span>
+      <span class="app-map__overlay-label">{{ locale.overlay.dateTime }}</span>
       <span class="app-map__overlay-value">{{ displayGpsDate }}</span>
     </div>
     <div class="app-map__overlay-row">
-      <span class="app-map__overlay-label">Lat / Lng</span>
+      <span class="app-map__overlay-label">{{ locale.overlay.latLng }}</span>
       <span class="app-map__overlay-value app-map__overlay-value--coords">{{ displayLatitude }}, {{ displayLongitude }}</span>
     </div>
   </template>
@@ -169,6 +169,6 @@
         </script>
      
     </div>
-    <p class="govuk-body-m"><a href="/map-help?returnUrl={{ currentUrl }}">Guide to the map</a></p>
+    <p class="govuk-body-m"><a href="/map-help?returnUrl={{ currentUrl }}">{{ locale.links.mapHelp }}</a></p>
   </div>
 {% endblock %}

--- a/server/views/partials/mapSearchForm.njk
+++ b/server/views/partials/mapSearchForm.njk
@@ -80,11 +80,13 @@
                     </div>
                      <div class="govuk-grid-column-one-third">
                         <div class="map-search__form-actions">
-                            {{ govukButton({
-                                text: locale.search.update,
-                                classes: "govuk-!-margin-right-2 govuk-!-margin-bottom-0"
-                            }) }}
-                            <a href="{{ form.action }}" class="govuk-link govuk-link--no-visited-state">{{ locale.search.clear }}</a>
+                            <div class="govuk-button-group">
+                                {{ govukButton({
+                                    text: locale.search.update,
+                                    classes: "govuk-!-margin-right-2 govuk-!-margin-bottom-0"
+                                }) }}
+                                <a href="{{ form.action }}" class="govuk-link govuk-link--no-visited-state">{{ locale.search.clear }}</a>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/server/views/partials/mapSearchForm.njk
+++ b/server/views/partials/mapSearchForm.njk
@@ -9,7 +9,7 @@
 
 {% if form.errorSummary and form.errorSummary | length %}
     {{ govukErrorSummary({
-        titleText: "There is a problem",
+        titleText: locale.search.errorSummaryTitle,
         errorList: form.errorSummary
     }) }}
 {% endif %}
@@ -29,7 +29,7 @@
 
 <div class="govuk-width-container">
     <div class="govuk-grid-row govuk-!-margin-bottom-3 govuk-!-margin-right-0 govuk-!-margin-left-0">
-        <h3 class="govuk-heading-s">Search map by date and time</h3>
+        <h3 class="govuk-heading-s">{{ locale.search.heading }}</h3>
         <div class="map-search govuk-!-padding-4">
             <form
                 id="dateFilterForm"
@@ -43,7 +43,7 @@
                 {{
                     govukInput({
                         label: {
-                        text: "CRN",
+                        text: locale.search.crn,
                         classes: "govuk-label--s"
                         },
                         classes: "govuk-date-input__input govuk-input--width-5",
@@ -58,8 +58,8 @@
                         {{ dtp.date_time_picker({
                             id: "start",
                             name: "start",
-                            labelText: "Date from",
-                            timeLabel: "Time from",
+                            labelText: locale.search.dateFrom,
+                            timeLabel: locale.search.timeFrom,
                             value: form.values.fromDate.date,
                             hour: form.values.fromDate.hour,
                             minute: form.values.fromDate.minute,
@@ -70,8 +70,8 @@
                         {{ dtp.date_time_picker({
                             id: "end",
                             name: "end",
-                            labelText: "Date to",
-                            timeLabel: "Time to",
+                            labelText: locale.search.dateTo,
+                            timeLabel: locale.search.timeTo,
                             value: form.values.toDate.date,
                             hour: form.values.toDate.hour,
                             minute: form.values.toDate.minute,
@@ -81,10 +81,10 @@
                      <div class="govuk-grid-column-one-third">
                         <div class="map-search__form-actions">
                             {{ govukButton({
-                                text: "Update map",
+                                text: locale.search.update,
                                 classes: "govuk-!-margin-right-2 govuk-!-margin-bottom-0"
                             }) }}
-                            <a href="{{ form.action }}" class="govuk-link govuk-link--no-visited-state">Clear filters</a>
+                            <a href="{{ form.action }}" class="govuk-link govuk-link--no-visited-state">{{ locale.search.clear }}</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
### Summary

Move server-rendered copy on the casesLocation page to a locale-backed JSON contract, following the same pattern already used for the map help page.

### Description

This change externalised the server-side text used by the Cases Location Activity view into a dedicated locale file and wired that locale through the cases controller into the Nunjucks templates.

A new cases-location.locale.json file was added and is now the source of truth for:

page heading
map accessibility text
map overlay labels
map help link text
date/time search form labels and actions
server-side alert messages for fetch failure and no-results states
The casesController.location() render model was updated to include the locale object, and the controller now uses locale values for the location error and empty-state alerts.

The following templates were updated to consume locale-backed strings instead of hardcoded copy:

server/views/pages/casesLocation.njk
server/views/partials/mapSearchForm.njk
Tests were updated so the location page render contract now expects locale in the view model. Relevant controller tests pass.

Also added hint text.

### Scope

Server-side only
No client-side map control localisation yet
Add new hint test

### Out of scope

JS-controlled strings in map UI components such as rotation control and layers panel
Broader shared/global localisation framework