### PR TITLE
Feat: EPT-817 - add session storage for controls

### DIFF
--- a/assets/js/views/cases/controls/mapLayersControl.test.ts
+++ b/assets/js/views/cases/controls/mapLayersControl.test.ts
@@ -17,10 +17,22 @@ jest.mock('@ministryofjustice/hmpps-electronic-monitoring-components/map/layers'
 
 const makeLayer = (id: string): ComposableLayer => ({ id }) as unknown as ComposableLayer
 
-const makeMockMap = (visible = true): EmMap =>
-  ({
-    getNativeLayer: jest.fn(() => ({ getVisible: jest.fn(() => visible) })),
-  }) as unknown as EmMap
+const makeNativeLayer = (visible = true) => ({
+  getVisible: jest.fn(() => visible),
+  setVisible: jest.fn(),
+})
+
+const makeMockMap = (visible = true): EmMap => {
+  const layers = {
+    tracks: makeNativeLayer(visible),
+    confidence: makeNativeLayer(visible),
+    numbers: makeNativeLayer(visible),
+  }
+
+  return {
+    getNativeLayer: jest.fn((id: keyof typeof layers) => layers[id]),
+  } as unknown as EmMap
+}
 
 const makeOpts = (map: EmMap) => ({
   tracksLayer: makeLayer('tracks'),
@@ -55,6 +67,109 @@ describe('MapLayersControl', () => {
       const openBtn = mapContainer.querySelector('.mlc-open-btn') as HTMLElement
       expect(openBtn).toBeTruthy()
       expect(openBtn.hasAttribute('data-hidden')).toBe(true)
+    })
+
+    it('renders controls from the provided initial state', () => {
+      const opts = makeOpts(makeMockMap())
+      mapContainer = opts.mapContainer
+
+      // eslint-disable-next-line no-new
+      new MapLayersControl({
+        ...opts,
+        initialState: {
+          baseLayer: 'satellite',
+          tracks: false,
+          confidence: true,
+          numbers: false,
+        },
+      })
+
+      expect((mapContainer.querySelector('#mlc-base-satellite') as HTMLInputElement).checked).toBe(true)
+      expect((mapContainer.querySelector('#mlc-base-street') as HTMLInputElement).checked).toBe(false)
+      expect((mapContainer.querySelector('#mlc-tracks') as HTMLInputElement).checked).toBe(false)
+      expect((mapContainer.querySelector('#mlc-confidence') as HTMLInputElement).checked).toBe(true)
+      expect((mapContainer.querySelector('#mlc-numbers') as HTMLInputElement).checked).toBe(false)
+    })
+
+    it('applies the initial state to layer visibility', () => {
+      const tracksNativeLayer = makeNativeLayer()
+      const confidenceNativeLayer = makeNativeLayer()
+      const numbersNativeLayer = makeNativeLayer()
+      const map = {
+        getNativeLayer: jest.fn((id: string) => {
+          if (id === 'tracks') return tracksNativeLayer
+          if (id === 'confidence') return confidenceNativeLayer
+          if (id === 'numbers') return numbersNativeLayer
+          return undefined
+        }),
+      } as unknown as EmMap
+      const opts = makeOpts(map)
+
+      // eslint-disable-next-line no-new
+      new MapLayersControl({
+        ...opts,
+        initialState: {
+          baseLayer: 'street',
+          tracks: false,
+          confidence: true,
+          numbers: false,
+        },
+      })
+
+      expect(tracksNativeLayer.setVisible).toHaveBeenCalledWith(false)
+      expect(confidenceNativeLayer.setVisible).toHaveBeenCalledWith(true)
+      expect(numbersNativeLayer.setVisible).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('when controls change', () => {
+    it('calls onChange with the current state for checkbox changes', () => {
+      const onChange = jest.fn()
+      const opts = makeOpts(makeMockMap())
+      mapContainer = opts.mapContainer
+
+      // eslint-disable-next-line no-new
+      new MapLayersControl({
+        ...opts,
+        initialState: {
+          baseLayer: 'street',
+          tracks: true,
+          confidence: true,
+          numbers: true,
+        },
+        onChange,
+      })
+
+      const tracks = mapContainer.querySelector('#mlc-tracks') as HTMLInputElement
+      tracks.checked = false
+      tracks.dispatchEvent(new Event('change'))
+
+      expect(onChange).toHaveBeenCalledWith({
+        baseLayer: 'street',
+        tracks: false,
+        confidence: true,
+        numbers: true,
+      })
+    })
+
+    it('calls onChange with the current state for base layer changes', () => {
+      const onChange = jest.fn()
+      const opts = makeOpts(makeMockMap())
+      mapContainer = opts.mapContainer
+
+      // eslint-disable-next-line no-new
+      new MapLayersControl({ ...opts, onChange })
+
+      const satellite = mapContainer.querySelector('#mlc-base-satellite') as HTMLInputElement
+      satellite.checked = true
+      satellite.dispatchEvent(new Event('change'))
+
+      expect(onChange).toHaveBeenCalledWith({
+        baseLayer: 'satellite',
+        tracks: true,
+        confidence: true,
+        numbers: true,
+      })
     })
   })
 

--- a/assets/js/views/cases/controls/mapLayersControls.ts
+++ b/assets/js/views/cases/controls/mapLayersControls.ts
@@ -5,6 +5,13 @@ import type BaseLayer from 'ol/layer/Base'
 import { ComposableLayer } from '@ministryofjustice/hmpps-electronic-monitoring-components/map/layers'
 import { EmMap } from '@ministryofjustice/hmpps-electronic-monitoring-components/map'
 
+export interface MapControlState {
+  baseLayer: 'street' | 'satellite'
+  tracks: boolean
+  confidence: boolean
+  numbers: boolean
+}
+
 interface MapLayersControlOptions {
   streetLayer?: TileLayer<TileSource>
   satelliteLayer?: TileLayer<TileSource>
@@ -13,6 +20,15 @@ interface MapLayersControlOptions {
   numbersLayer?: ComposableLayer
   mapContainer: HTMLElement
   map: EmMap
+  initialState?: MapControlState
+  onChange?: (state: MapControlState) => void
+}
+
+const defaultMapControlState: MapControlState = {
+  baseLayer: 'street',
+  tracks: true,
+  confidence: true,
+  numbers: true,
 }
 
 export default class MapLayersControl extends Control {
@@ -36,6 +52,8 @@ export default class MapLayersControl extends Control {
   }
 
   private static createPanel(opts: MapLayersControlOptions): { panel: HTMLElement; openBtn: HTMLElement } {
+    const state: MapControlState = { ...defaultMapControlState, ...opts.initialState }
+
     const openBtn = document.createElement('button')
     openBtn.setAttribute('aria-label', 'Open layers panel')
     openBtn.className = 'govuk-button govuk-button--secondary mlc-open-btn'
@@ -66,11 +84,11 @@ export default class MapLayersControl extends Control {
         <fieldset class="govuk-fieldset">
             <div class="govuk-radios govuk-radios--small" data-module="govuk-radios">
                 <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="mlc-base-street" name="mlc-base" type="radio" value="street" checked>
+                  <input class="govuk-radios__input" id="mlc-base-street" name="mlc-base" type="radio" value="street" ${state.baseLayer === 'street' ? 'checked' : ''}>
                   <label class="govuk-label govuk-radios__label" for="mlc-base-street">Street</label>
                 </div>
                 <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="mlc-base-satellite" name="mlc-base" type="radio" value="satellite">
+                  <input class="govuk-radios__input" id="mlc-base-satellite" name="mlc-base" type="radio" value="satellite" ${state.baseLayer === 'satellite' ? 'checked' : ''}>
                   <label class="govuk-label govuk-radios__label" for="mlc-base-satellite">Satellite</label>
                 </div>
             </div>
@@ -83,39 +101,51 @@ export default class MapLayersControl extends Control {
         <fieldset class="govuk-fieldset">
           <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="mlc-tracks" type="checkbox" ${(opts.map.getNativeLayer(opts.tracksLayer.id) as BaseLayer)?.getVisible() ? 'checked' : ''}>
+              <input class="govuk-checkboxes__input" id="mlc-tracks" type="checkbox" ${state.tracks ? 'checked' : ''}>
               <label class="govuk-label govuk-checkboxes__label" for="mlc-tracks">Direction of travel</label>
             </div>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="mlc-confidence" type="checkbox" ${(opts.map.getNativeLayer(opts.confidenceLayer?.id) as BaseLayer | undefined)?.getVisible() ? 'checked' : ''}>
+              <input class="govuk-checkboxes__input" id="mlc-confidence" type="checkbox" ${state.confidence ? 'checked' : ''}>
               <label class="govuk-label govuk-checkboxes__label" for="mlc-confidence">Location accuracy</label>
             </div>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="mlc-numbers" type="checkbox" ${(opts.map.getNativeLayer(opts.numbersLayer?.id) as BaseLayer | undefined)?.getVisible() ? 'checked' : ''}>
+              <input class="govuk-checkboxes__input" id="mlc-numbers" type="checkbox" ${state.numbers ? 'checked' : ''}>
               <label class="govuk-label govuk-checkboxes__label" for="mlc-numbers">Point numbers</label>
             </div>
           </div>
         </fieldset>
       </div>`
 
+    const notifyChange = () => opts.onChange?.({ ...state })
+
+    opts.streetLayer?.setVisible(state.baseLayer === 'street')
+    opts.satelliteLayer?.setVisible(state.baseLayer === 'satellite')
+
     panel.querySelectorAll('[name="mlc-base"]').forEach(radio =>
       radio.addEventListener('change', e => {
         const val = (e.target as HTMLInputElement).value
+        state.baseLayer = val === 'satellite' ? 'satellite' : 'street'
         opts.streetLayer?.setVisible(val === 'street')
         opts.satelliteLayer?.setVisible(val === 'satellite')
+        notifyChange()
       }),
     )
 
-    const bindCheckbox = (id: string, layer?: ComposableLayer) => {
+    const bindCheckbox = (id: string, stateKey: 'tracks' | 'confidence' | 'numbers', layer?: ComposableLayer) => {
       const input = panel.querySelector(id) as HTMLInputElement | null
       if (!input || !layer) return
       const nativeLayer = opts.map.getNativeLayer(layer.id)
-      input.addEventListener('change', () => nativeLayer?.setVisible(input.checked))
+      ;(nativeLayer as BaseLayer | undefined)?.setVisible(state[stateKey])
+      input.addEventListener('change', () => {
+        state[stateKey] = input.checked
+        ;(nativeLayer as BaseLayer | undefined)?.setVisible(input.checked)
+        notifyChange()
+      })
     }
 
-    bindCheckbox('#mlc-tracks', opts.tracksLayer)
-    bindCheckbox('#mlc-confidence', opts.confidenceLayer)
-    bindCheckbox('#mlc-numbers', opts.numbersLayer)
+    bindCheckbox('#mlc-tracks', 'tracks', opts.tracksLayer)
+    bindCheckbox('#mlc-confidence', 'confidence', opts.confidenceLayer)
+    bindCheckbox('#mlc-numbers', 'numbers', opts.numbersLayer)
 
     panel.querySelector('.mlc-panel__close')?.addEventListener('click', () => {
       toggle(panel, openBtn)

--- a/assets/js/views/cases/index.test.ts
+++ b/assets/js/views/cases/index.test.ts
@@ -11,6 +11,7 @@ import {
 import { EmMap } from '@ministryofjustice/hmpps-electronic-monitoring-components/map'
 import initialiseLocationDataView from './index'
 import * as utils from '../../utils/utils'
+import MapLayersControl from './controls/mapLayersControls'
 
 interface MockOlMapInstance {
   addControl: jest.Mock
@@ -63,6 +64,7 @@ jest.mock('../../utils/utils')
 describe('initialiseLocationDataView', () => {
   let mockEmMap: MockEmMapWithShadow
   let mockMap: MockOlMapInstance
+  let mockMapContainer: HTMLElement
   const mockCompassReset = { setAttribute: jest.fn() }
   const mockZoomSliderThumb = { setAttribute: jest.fn() }
   const mockInsertBefore = jest.fn()
@@ -95,7 +97,10 @@ describe('initialiseLocationDataView', () => {
         querySelector: jest.fn(),
       },
     }
+    mockMapContainer = document.createElement('div')
     ;(utils.queryElement as jest.Mock).mockImplementation((_root: unknown, selector: string) => {
+      if (selector === '[data-qa="em-map"]') return mockMapContainer
+      if (selector === 'em-map') return mockEmMap as unknown as EmMap
       if (selector === '.ol-rotate-reset') return mockCompassReset
       if (selector === '.ol-zoomslider-thumb') return mockZoomSliderThumb
       if (selector === '.ol-zoomslider') return mockOlZoomSlider
@@ -105,6 +110,7 @@ describe('initialiseLocationDataView', () => {
   })
 
   afterEach(() => {
+    document.body.innerHTML = ''
     jest.clearAllMocks()
   })
 
@@ -123,6 +129,54 @@ describe('initialiseLocationDataView', () => {
   it('should add TracksLayer with visible set to true', () => {
     initialiseLocationDataView()
     expect(TracksLayer).toHaveBeenCalledWith(expect.objectContaining({ visible: true }))
+  })
+
+  it('should initialise custom layers and map controls from the persisted map control state', () => {
+    mockMapContainer.dataset.mapControlBaseLayer = 'satellite'
+    mockMapContainer.dataset.mapControlTracks = 'false'
+    mockMapContainer.dataset.mapControlConfidence = 'true'
+    mockMapContainer.dataset.mapControlNumbers = 'false'
+
+    initialiseLocationDataView()
+
+    expect(TracksLayer).toHaveBeenCalledWith(expect.objectContaining({ visible: false }))
+    expect(CirclesLayer).toHaveBeenCalledWith(expect.objectContaining({ visible: true }))
+    expect(TextLayer).toHaveBeenCalledWith(expect.objectContaining({ visible: false }))
+    expect(MapLayersControl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialState: {
+          baseLayer: 'satellite',
+          tracks: false,
+          confidence: true,
+          numbers: false,
+        },
+        onChange: expect.any(Function),
+      }),
+    )
+  })
+
+  it('should keep map control hidden inputs in sync', () => {
+    document.body.innerHTML = `
+      <input data-map-control-input="baseLayer" value="street">
+      <input data-map-control-input="tracks" value="true">
+      <input data-map-control-input="confidence" value="true">
+      <input data-map-control-input="numbers" value="true">
+    `
+
+    initialiseLocationDataView()
+
+    const mapLayersControlOptions = (MapLayersControl as unknown as jest.Mock).mock.calls[0][0]
+    mapLayersControlOptions.onChange({
+      baseLayer: 'satellite',
+      tracks: false,
+      confidence: true,
+      numbers: false,
+    })
+
+    expect(document.querySelector<HTMLInputElement>('[data-map-control-input="baseLayer"]')?.value).toBe('satellite')
+    expect(document.querySelector<HTMLInputElement>('[data-map-control-input="tracks"]')?.value).toBe('false')
+    expect(document.querySelector<HTMLInputElement>('[data-map-control-input="confidence"]')?.value).toBe('true')
+    expect(document.querySelector<HTMLInputElement>('[data-map-control-input="numbers"]')?.value).toBe('false')
   })
 
   it('should add a CirclesLayer to the map', () => {
@@ -203,6 +257,8 @@ describe('initialiseLocationDataView', () => {
 
     it('should not throw if zoom slider or rotate control is missing', () => {
       ;(utils.queryElement as jest.Mock).mockImplementation((_root: unknown, selector: string) => {
+        if (selector === '[data-qa="em-map"]') return mockMapContainer
+        if (selector === 'em-map') return mockEmMap as unknown as EmMap
         if (selector === '.ol-rotate-reset') return mockCompassReset
         if (selector === '.ol-zoomslider-thumb') return mockZoomSliderThumb
         if (selector === '.ol-zoomslider') return null

--- a/assets/js/views/cases/index.ts
+++ b/assets/js/views/cases/index.ts
@@ -7,7 +7,7 @@ import {
 } from '@ministryofjustice/hmpps-electronic-monitoring-components/map/layers'
 import { isEmpty } from 'ol/extent'
 import type VectorLayer from 'ol/layer/Vector'
-import MapLayersControl from './controls/mapLayersControls'
+import MapLayersControl, { MapControlState } from './controls/mapLayersControls'
 import getRotatedDirection from './controls/getRotatedDirection'
 import createLockRotationControl from './controls/createLockRotationControl'
 import { queryElement } from '../../utils/utils'
@@ -17,6 +17,35 @@ interface ShadowRootHost extends HTMLElement {
 }
 
 const getShadowRoot = (emMap: EmMap): ShadowRoot | null => (emMap as ShadowRootHost).shadowRoot
+
+const defaultMapControlState: MapControlState = {
+  baseLayer: 'street',
+  tracks: true,
+  confidence: true,
+  numbers: true,
+}
+
+const parseBooleanDataValue = (value: string | undefined): boolean | undefined => {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  return undefined
+}
+
+const getInitialMapControlState = (mapContainer: HTMLElement): MapControlState => ({
+  baseLayer: mapContainer.dataset.mapControlBaseLayer === 'satellite' ? 'satellite' : 'street',
+  tracks: parseBooleanDataValue(mapContainer.dataset.mapControlTracks) ?? defaultMapControlState.tracks,
+  confidence: parseBooleanDataValue(mapContainer.dataset.mapControlConfidence) ?? defaultMapControlState.confidence,
+  numbers: parseBooleanDataValue(mapContainer.dataset.mapControlNumbers) ?? defaultMapControlState.numbers,
+})
+
+const syncMapControlInputs = (state: MapControlState) => {
+  ;(Object.keys(state) as Array<keyof MapControlState>).forEach(key => {
+    const input = document.querySelector<HTMLInputElement>(`[data-map-control-input="${key}"]`)
+    if (input) {
+      input.value = String(state[key])
+    }
+  })
+}
 
 const initialiseDirectionScreenReader = () => {
   const emMap = queryElement(document, 'em-map') as EmMap
@@ -80,6 +109,8 @@ const initialiseLocationDataView = () => {
     }
     injectShadowFocusStyles(emMap as EmMap)
     const { positions } = emMap
+    const mapControlState = getInitialMapControlState(mapContainer)
+    syncMapControlInputs(mapControlState)
 
     const locationsLayer = emMap.addLayer(
       new LocationsLayer({
@@ -98,7 +129,7 @@ const initialiseLocationDataView = () => {
     const tracksLayer = new TracksLayer({
       id: 'tracksLayer',
       positions,
-      visible: true,
+      visible: mapControlState.tracks,
       zIndex: 1,
     })
 
@@ -106,7 +137,7 @@ const initialiseLocationDataView = () => {
       positions,
       id: 'confidenceLayer',
       title: 'confidenceLayer',
-      visible: true,
+      visible: mapControlState.confidence,
       zIndex: 3,
       style: {
         fill: 'rgba(0, 0, 0, 0)',
@@ -121,7 +152,7 @@ const initialiseLocationDataView = () => {
       textProperty: 'displayPointNumber',
       id: 'numbersLayer',
       title: 'numbersLayer',
-      visible: true,
+      visible: mapControlState.numbers,
       zIndex: 3,
       style: {
         offset: { x: 0, y: 30 },
@@ -145,6 +176,8 @@ const initialiseLocationDataView = () => {
       tracksLayer,
       confidenceLayer,
       numbersLayer,
+      initialState: mapControlState,
+      onChange: syncMapControlInputs,
     })
     map.addControl(mapLayersControl)
 

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,5 +1,6 @@
 import { HmppsUser } from '../../interfaces/hmppsUser'
 import { ValidationResult } from '../../models/ValidationResult'
+import { LocationMapControls } from '../../types/locationMapControls'
 
 export declare module 'express-session' {
   interface SelectedPersonContext {
@@ -17,6 +18,7 @@ export declare module 'express-session' {
     validationErrors: ValidationResult
     queryId: string
     peopleSelection: Record<string, SelectedPersonContext>
+    locationMapControls?: LocationMapControls
   }
 }
 

--- a/server/controllers/cases/casesController.test.ts
+++ b/server/controllers/cases/casesController.test.ts
@@ -134,6 +134,108 @@ describe('CasesController', () => {
       )
     })
 
+    it('should render default map controls when session is empty', async () => {
+      req.query = { crn: 'X172591' }
+      req.session = {} as Request['session']
+
+      await controller.location(req as Request, res as Response)
+
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/casesLocation',
+        expect.objectContaining({
+          mapControls: {
+            baseLayer: 'street',
+            tracks: true,
+            confidence: true,
+            numbers: true,
+          },
+        }),
+      )
+    })
+
+    it('should use map controls stored in session', async () => {
+      req.query = { crn: 'X172591' }
+      req.session = {
+        locationMapControls: {
+          baseLayer: 'satellite',
+          tracks: false,
+          confidence: true,
+          numbers: false,
+        },
+      } as Request['session']
+
+      await controller.location(req as Request, res as Response)
+
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/casesLocation',
+        expect.objectContaining({
+          mapControls: {
+            baseLayer: 'satellite',
+            tracks: false,
+            confidence: true,
+            numbers: false,
+          },
+        }),
+      )
+    })
+
+    it('should update map controls in session from valid query parameters', async () => {
+      req.query = {
+        crn: 'X172591',
+        mapControls: {
+          baseLayer: 'satellite',
+          tracks: 'false',
+          confidence: 'true',
+          numbers: 'false',
+        },
+      }
+      req.session = {} as Request['session']
+
+      await controller.location(req as Request, res as Response)
+
+      expect(req.session.locationMapControls).toEqual({
+        baseLayer: 'satellite',
+        tracks: false,
+        confidence: true,
+        numbers: false,
+      })
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/casesLocation',
+        expect.objectContaining({
+          mapControls: req.session.locationMapControls,
+        }),
+      )
+    })
+
+    it('should ignore invalid map control query parameters', async () => {
+      req.query = {
+        crn: 'X172591',
+        mapControls: {
+          baseLayer: 'hybrid',
+          tracks: 'yes',
+          confidence: 'no',
+          numbers: 'invalid',
+        },
+      }
+      req.session = {
+        locationMapControls: {
+          baseLayer: 'satellite',
+          tracks: false,
+          confidence: false,
+          numbers: true,
+        },
+      } as Request['session']
+
+      await controller.location(req as Request, res as Response)
+
+      expect(req.session.locationMapControls).toEqual({
+        baseLayer: 'satellite',
+        tracks: false,
+        confidence: false,
+        numbers: true,
+      })
+    })
+
     it('should handle validation errors and render location activity tab with errors', async () => {
       const validationErrors = [{ field: 'fromDate', message: 'Invalid date' }] as ValidationError[]
       dateSearchValidationService.validateDateSearchRequest.mockReturnValue({

--- a/server/controllers/cases/casesController.ts
+++ b/server/controllers/cases/casesController.ts
@@ -15,6 +15,7 @@ import { getDateComponents, parseDateTimeFromISOString } from '../../utils/date'
 import { ValidationResult } from '../../models/ValidationResult'
 import { convertZodErrorToValidationError } from '../../utils/errors'
 import casesLocationLocale from './cases-location.locale.json'
+import { defaultLocationMapControls, LocationMapControls } from '../../types/locationMapControls'
 
 interface LocationDateFilterFormData {
   date: string
@@ -43,6 +44,7 @@ interface QueryParams {
     minute?: string
   }
   crn?: string
+  mapControls?: Partial<Record<keyof LocationMapControls, unknown>>
 }
 
 interface ValidationError {
@@ -112,6 +114,40 @@ export default class CasesController {
   private persistFormState(req: Request, errors: ValidationResult, formData: LocationBuildProps): void {
     req.session!.validationErrors = errors
     req.session!.formData = formData
+  }
+
+  private parseBooleanMapControlValue(value: unknown): boolean | undefined {
+    if (value === 'true') return true
+    if (value === 'false') return false
+    return undefined
+  }
+
+  private buildLocationMapControls(req: Request): LocationMapControls {
+    const sessionControls: Partial<LocationMapControls> = req.session?.locationMapControls || {}
+    const queryControls = (req.query as QueryParams).mapControls || {}
+
+    const baseLayer =
+      queryControls.baseLayer === 'street' || queryControls.baseLayer === 'satellite'
+        ? queryControls.baseLayer
+        : sessionControls.baseLayer
+
+    const controls: LocationMapControls = {
+      ...defaultLocationMapControls,
+      ...sessionControls,
+      ...(baseLayer ? { baseLayer } : {}),
+    }
+
+    ;(['tracks', 'confidence', 'numbers'] as const).forEach(key => {
+      const value = this.parseBooleanMapControlValue(queryControls[key])
+      if (value !== undefined) {
+        controls[key] = value
+      }
+    })
+
+    if (req.session) {
+      req.session.locationMapControls = controls
+    }
+    return controls
   }
 
   async overview(req: Request, res: Response): Promise<void> {
@@ -193,6 +229,7 @@ export default class CasesController {
     let locationAlert: { text: string } | null = null
     let queryRange = { fromDate: '', toDate: '' }
     let formValues: LocationBuildProps
+    const mapControls = this.buildLocationMapControls(req)
 
     const hasQueryParams = req.query.start !== undefined || req.query.end !== undefined
 
@@ -278,6 +315,7 @@ export default class CasesController {
       fromDate: queryRange.fromDate,
       toDate: queryRange.toDate,
       locationAlert,
+      mapControls,
       currentUrl: encodeURIComponent(String(req.originalUrl)),
     })
   }

--- a/server/testutils/factories/locationPage.factory.ts
+++ b/server/testutils/factories/locationPage.factory.ts
@@ -66,6 +66,7 @@ export interface LocationPageRenderData {
   showComplianceBadge: boolean
   toDate: string
   currentUrl?: string
+  mapControls: LocationMapControls
 }
 
 export interface LocationApiResponse {
@@ -78,6 +79,13 @@ export interface LocationApiResponse {
 export interface DateFilters {
   from?: string
   to?: string
+}
+
+export interface LocationMapControls {
+  baseLayer: 'street' | 'satellite'
+  tracks: boolean
+  confidence: boolean
+  numbers: boolean
 }
 
 // ============================================================================
@@ -94,6 +102,13 @@ const defaultPopData = (): PopData => ({
   crn: 'X172591',
   dateOfBirth: '1964-10-07',
   tier: 'B3',
+})
+
+const defaultMapControls = (): LocationMapControls => ({
+  baseLayer: 'street',
+  tracks: true,
+  confidence: true,
+  numbers: true,
 })
 
 const defaultDateFilterForm = (): DateFilterForm => ({
@@ -273,6 +288,7 @@ export const buildLocationPageRenderData = (
     positions: [],
     showComplianceBadge: true,
     toDate: '',
+    mapControls: defaultMapControls(),
   }
 
   return {

--- a/server/types/locationMapControls.ts
+++ b/server/types/locationMapControls.ts
@@ -1,0 +1,15 @@
+export type MapBaseLayer = 'street' | 'satellite'
+
+export interface LocationMapControls {
+  baseLayer: MapBaseLayer
+  tracks: boolean
+  confidence: boolean
+  numbers: boolean
+}
+
+export const defaultLocationMapControls: LocationMapControls = {
+  baseLayer: 'street',
+  tracks: true,
+  confidence: true,
+  numbers: true,
+}

--- a/server/views/pages/casesLocation.njk
+++ b/server/views/pages/casesLocation.njk
@@ -32,6 +32,10 @@
     </div>
     <div class="em-map" 
         data-qa="em-map" 
+        data-map-control-base-layer="{{ mapControls.baseLayer }}"
+        data-map-control-tracks="{{ mapControls.tracks }}"
+        data-map-control-confidence="{{ mapControls.confidence }}"
+        data-map-control-numbers="{{ mapControls.numbers }}"
         role="region" 
         aria-label="{{ locale.map.ariaLabel }}" aria-describedby="map-instructions"
         tabindex="0">

--- a/server/views/partials/mapSearchForm.njk
+++ b/server/views/partials/mapSearchForm.njk
@@ -38,6 +38,10 @@
                 class="map-search__form govuk-form-group govuk-!-margin-bottom-0"
                 method="get">
                 <input type="hidden" name="_csrf" value="{{ csrftoken }}" />
+                <input type="hidden" name="mapControls[baseLayer]" value="{{ mapControls.baseLayer }}" data-map-control-input="baseLayer" />
+                <input type="hidden" name="mapControls[tracks]" value="{{ mapControls.tracks }}" data-map-control-input="tracks" />
+                <input type="hidden" name="mapControls[confidence]" value="{{ mapControls.confidence }}" data-map-control-input="confidence" />
+                <input type="hidden" name="mapControls[numbers]" value="{{ mapControls.numbers }}" data-map-control-input="numbers" />
 
                 <div class="govuk-form-group">
                 {{


### PR DESCRIPTION
## Summary

Adds persistence for the case location map layer controls so user selections are retained when the location activity page reloads or the date search form is submitted.

## Changes

- Added a `LocationMapControls` type with default map control values.
- Stores location map control state in the user session.
- Accepts map control state from query parameters and validates supported values.
- Passes persisted map control state into the location page render data.
- Adds hidden form inputs so map layer selections are submitted with the map search form.
- Initialises the frontend map layers from persisted state:
  - base layer: street or satellite
  - direction of travel
  - location accuracy
  - point numbers
- Keeps hidden form inputs in sync when map controls change.
- Adds controller and frontend tests for default, persisted, updated, and invalid control states.

## Testing

- Added unit coverage for `CasesController` map control session behaviour.
- Added frontend tests for map control initial state, layer visibility, and form input syncing.