### PR TITLE
Feat: EPT-841 - add page tracking

### DIFF
--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -8,12 +8,39 @@ import {
 import { RequestHandler } from 'express'
 import type { ApplicationInfo } from '../applicationInfo'
 
+type WebInstrumentationConfig = {
+  name: string
+  value: string | boolean | number
+}
+
+function addWebInstrumentationConfig(): void {
+  const appInsightsConfig = (
+    process.env.APPLICATIONINSIGHTS_CONFIGURATION_CONTENT
+      ? JSON.parse(process.env.APPLICATIONINSIGHTS_CONFIGURATION_CONTENT)
+      : {}
+  ) as { webInstrumentationConfig?: WebInstrumentationConfig[] }
+  const webInstrumentationConfig = Array.isArray(appInsightsConfig.webInstrumentationConfig)
+    ? appInsightsConfig.webInstrumentationConfig.filter(({ name }) => name !== 'autoTrackPageVisitTime')
+    : []
+
+  process.env.APPLICATIONINSIGHTS_CONFIGURATION_CONTENT = JSON.stringify({
+    ...appInsightsConfig,
+    webInstrumentationConfig: [...webInstrumentationConfig, { name: 'autoTrackPageVisitTime', value: true }],
+  })
+}
+
 export function initialiseAppInsights(): void {
   if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
     // eslint-disable-next-line no-console
     console.log('Enabling azure application insights')
 
-    setup().setDistributedTracingMode(DistributedTracingModes.AI_AND_W3C).start()
+    addWebInstrumentationConfig()
+
+    const appInsights = setup()
+      .setDistributedTracingMode(DistributedTracingModes.AI_AND_W3C)
+      .enableWebInstrumentation(true)
+
+    appInsights.start()
   }
 }
 


### PR DESCRIPTION
## Summary

Enables browser-side Application Insights web instrumentation and turns on page visit time tracking.

## Changes

- Enables App Insights web instrumentation during server App Insights initialisation.
- Adds `autoTrackPageVisitTime: true` to the web instrumentation config.
- Applies the config before `setup()` runs so the Node SDK includes it when constructing the injected browser snippet.
- Preserves any existing `APPLICATIONINSIGHTS_CONFIGURATION_CONTENT` values and only replaces an existing `autoTrackPageVisitTime` entry if present.
