### PR TITLE
chore: Increase EMDI API timeouts across environments

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,8 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     EMDI_API_URL: 'https://electronic-monitoring-data-insights-api-dev.hmpps.service.justice.gov.uk'
+    EMDI_API_TIMEOUT_RESPONSE: "10000"
+    EMDI_API_TIMEOUT_DEADLINE: "15000"
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: "false"
     COMPONENT_API_URL: "https://probation-frontend-components-dev.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,8 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
     EMDI_API_URL: 'https://electronic-monitoring-data-insights-api-preprod.hmpps.service.justice.gov.uk'
+    EMDI_API_TIMEOUT_RESPONSE: "10000"
+    EMDI_API_TIMEOUT_DEADLINE: "15000"
     ENVIRONMENT_NAME: PRE-PRODUCTION
     AUDIT_ENABLED: "false"
     COMPONENT_API_URL: "https://probation-frontend-components-preprod.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,6 +10,8 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
     EMDI_API_URL: 'https://electronic-monitoring-data-insights-api.hmpps.service.justice.gov.uk'
+    EMDI_API_TIMEOUT_RESPONSE: "10000"
+    EMDI_API_TIMEOUT_DEADLINE: "15000"
     AUDIT_ENABLED: "false"
     COMPONENT_API_URL: "https://probation-frontend-components.hmpps.service.justice.gov.uk"
 


### PR DESCRIPTION
## Summary

Increase the deployed EMDI API timeout configuration across dev, preprod and prod.

## Changes

- Sets `EMDI_API_TIMEOUT_RESPONSE` to `10000`
- Sets `EMDI_API_TIMEOUT_DEADLINE` to `15000`
- Applies the same values across dev, preprod and prod Helm values

## Reason

Some location activity requests in preprod are taking longer than the previous 5 second default, causing the UI to show a fetch error before the API responds. Prod may hit the same issue with real-world data volumes, so this applies the timeout consistently across deployed environments.

## Testing

- Not run: Helm environment configuration change only.