### PR TITLE
feat: fix no person redirect issue

### DIFF
--- a/server/controllers/people/peopleController.test.ts
+++ b/server/controllers/people/peopleController.test.ts
@@ -123,6 +123,36 @@ describe('PeopleController', () => {
 
     expect(res.redirect).toHaveBeenCalledWith('/people/X31092/locations')
     expect(res.render).not.toHaveBeenCalled()
+    expect(req.session).toEqual({
+      peopleSelection: {
+        X31092: {
+          personId: '41591',
+          consumerId: '9b74b1071beb2210743d8551f54bcbcc',
+          fullName: 'DEVWR0004718',
+          dateOfBirth: '2020-01-01',
+        },
+      },
+    })
+  })
+
+  it('renders person not found instead of redirecting onward when redirectTo is provided and no person is found', async () => {
+    peopleService.searchPeople.mockResolvedValue({
+      people: [],
+      nextToken: null,
+    })
+    req.query = { redirectTo: '/people/X31092/locations' }
+
+    await controller.getPersonByDeliusId(req as Request, res as Response)
+
+    expect(res.redirect).not.toHaveBeenCalled()
+    expect(req.session).toEqual({})
+    expect(res.render).toHaveBeenCalledWith('pages/person', {
+      activeNav: 'people',
+      fullName: 'Person not found',
+      popData: null,
+      showComplianceBadge: false,
+      person: null,
+    })
   })
 
   it('does not redirect to an unrecognised redirectTo path', async () => {

--- a/server/controllers/people/peopleController.ts
+++ b/server/controllers/people/peopleController.ts
@@ -161,7 +161,7 @@ export default class PeopleController {
 
     const redirectTo = this.getAllowedRedirectTo(req, deliusId)
 
-    if (redirectTo) {
+    if (redirectTo && person) {
       res.redirect(redirectTo)
       return
     }


### PR DESCRIPTION
Fixing my mistakes. 

What changed:

- Strengthened the existing redirect test to assert the selected person is stored in session before redirecting.
- Added a test for redirectTo being present but no person found: it now asserts no redirect, no session hydration, and renders the “Person not found” page.