### PR TITLE
Feat/acc fixes

### DIFF
--- a/accessibility_tests/e2e/accessibility.spec.ts
+++ b/accessibility_tests/e2e/accessibility.spec.ts
@@ -38,6 +38,7 @@ test.describe('Accessibility', () => {
     await goToCasesPage(page)
 
     await page.locator('[data-qa=cases-sub-navigation]').getByRole('link', { name: 'Location activity' }).click()
+    await page.locator('#crn').fill('X123456')
     await page.locator('#start-date').fill('01/01/2026')
     await page.locator('#start-hour').fill('10')
     await page.locator('#start-minute').fill('00')

--- a/accessibility_tests/support/accessibility.ts
+++ b/accessibility_tests/support/accessibility.ts
@@ -2,6 +2,13 @@ import { AxeBuilder } from '@axe-core/playwright'
 import { expect, type Page } from '@playwright/test'
 
 const expectNoAccessibilityViolations = async (page: Page): Promise<void> => {
+  if ((await page.locator('[data-qa=em-map]').count()) > 0) {
+    await page.waitForFunction(() => {
+      const map = document.querySelector('em-map') as HTMLElement & { shadowRoot: ShadowRoot | null }
+      return map?.shadowRoot?.querySelector('.ol-zoomslider-thumb')?.getAttribute('aria-label') === 'Adjust map zoom'
+    })
+  }
+
   const results = await new AxeBuilder({ page })
     .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'])
     .analyze()

--- a/accessibility_tests/support/setup.ts
+++ b/accessibility_tests/support/setup.ts
@@ -3,13 +3,37 @@ import { expect, type Page } from '@playwright/test'
 import auth from '../../integration_tests/mockApis/auth'
 import emdiApi from '../../integration_tests/mockApis/emdiApi'
 import locationActivity from '../../integration_tests/mockApis/locationActivity'
-import { resetStubs } from '../../integration_tests/mockApis/wiremock'
+import { resetStubs, stubFor } from '../../integration_tests/mockApis/wiremock'
 import vectorStyle from '../../integration_tests/fixtures/vectorStyle.json'
 
 export const stubCommonApis = async (): Promise<void> => {
   await resetStubs()
   await auth.stubSignIn()
   await emdiApi.stubExampleTime()
+  await stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/components/api/components.*',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: {
+        header: {
+          html: '<header class="probation-common-header govuk-!-display-none-print" role="banner"><a class="probation-common-header__link" href="/">HMPPS</a></header>',
+          css: [],
+          javascript: [],
+        },
+        footer: {
+          html: '<footer class="govuk-footer" role="contentinfo"></footer>',
+          css: [],
+          javascript: [],
+        },
+      },
+    },
+  })
 }
 
 export const signIn = async (page: Page): Promise<void> => {
@@ -21,7 +45,7 @@ export const signIn = async (page: Page): Promise<void> => {
 }
 
 export const goToCasesPage = async (page: Page): Promise<void> => {
-  await page.locator('[data-qa=primary-navigation]').getByRole('link', { name: 'Cases' }).click()
+  await page.goto('/cases/1/overview')
   await expect(page.getByRole('heading', { name: 'Adam Collins' })).toBeVisible()
 }
 

--- a/feature.env
+++ b/feature.env
@@ -12,3 +12,5 @@ CLIENT_CREDS_CLIENT_SECRET=clientsecret
 ENVIRONMENT_NAME=dev
 COMPONENT_API_URL=http://localhost:9091/components
 TRAIL_DATA_BASE_URL=http://localhost:9091
+FLIPT_URL=http://localhost:9091/flipt
+FLIPT_NAMESPACE=hmpps-electronic-monitoring-data-insights

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,8 +17,8 @@ generic-service:
     ENVIRONMENT_NAME: DEV
     AUDIT_ENABLED: "false"
     COMPONENT_API_URL: "https://probation-frontend-components-dev.hmpps.service.justice.gov.uk"
-    ENABLE_HEATMAP: "false"
-    ENABLE_PING_CARD_NAVIGATION: "false"
+    FLIPT_URL: "https://feature-toggles-dev.hmpps.service.justice.gov.uk"
+    FLIPT_NAMESPACE: "hmpps-electronic-monitoring-data-insights"
     MPOP_URL: "https://manage-people-on-probation-dev.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,8 +18,8 @@ generic-service:
     AUDIT_ENABLED: "false"
     COMPONENT_API_URL: "https://probation-frontend-components-preprod.hmpps.service.justice.gov.uk"
     MPOP_URL: "https://manage-people-on-probation-preprod.hmpps.service.justice.gov.uk"
-    ENABLE_HEATMAP: "false"
-    ENABLE_PING_CARD_NAVIGATION: "false"
+    FLIPT_URL: "https://feature-toggles-preprod.hmpps.service.justice.gov.uk"
+    FLIPT_NAMESPACE: "hmpps-electronic-monitoring-data-insights"
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-electronic-monitoring-data-insights-preprod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,7 +15,7 @@ generic-service:
     AUDIT_ENABLED: "false"
     COMPONENT_API_URL: "https://probation-frontend-components.hmpps.service.justice.gov.uk"
     MPOP_URL: "https://manage-people-on-probation.hmpps.service.justice.gov.uk"
-    ENABLE_HEATMAP: "false"
-    ENABLE_PING_CARD_NAVIGATION: "false"
+    FLIPT_URL: "https://feature-toggles.hmpps.service.justice.gov.uk"
+    FLIPT_NAMESPACE: "hmpps-electronic-monitoring-data-insights"
 generic-prometheus-alerts:
   alertSeverity: hmpps-electronic-monitoring-data-insights-prod

--- a/integration_tests/mockApis/flipt.ts
+++ b/integration_tests/mockApis/flipt.ts
@@ -1,0 +1,39 @@
+import { SuperAgentRequest } from 'superagent'
+import { stubFor } from './wiremock'
+
+const flag = (key: string, enabled: boolean) => ({
+  key,
+  name: key,
+  description: '',
+  enabled,
+  type: 'BOOLEAN_FLAG_TYPE',
+  createdAt: '2026-06-24T00:00:00.000000Z',
+  updatedAt: '2026-06-24T00:00:00.000000Z',
+  rules: [] as unknown[],
+  rollouts: [] as unknown[],
+})
+
+export default {
+  stubFeatureFlags: ({
+    enableHeatmap = true,
+    enablePingCardNavigation = true,
+  }: {
+    enableHeatmap?: boolean
+    enablePingCardNavigation?: boolean
+  } = {}): SuperAgentRequest =>
+    stubFor({
+      request: {
+        urlPathPattern: '/flipt/internal/v1/evaluation/snapshot/namespace/hmpps-electronic-monitoring-data-insights',
+        method: 'GET',
+      },
+      response: {
+        status: 200,
+        jsonBody: {
+          namespace: {
+            key: 'hmpps-electronic-monitoring-data-insights',
+          },
+          flags: [flag('enable-heatmap', enableHeatmap), flag('enable-ping-card-navigation', enablePingCardNavigation)],
+        },
+      },
+    }),
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.803.0",
+        "@flipt-io/flipt-client-js": "0.5.0",
         "@ministryofjustice/frontend": "9.0.0",
         "@ministryofjustice/hmpps-auth-clients": "^0.0.1-alpha.4",
         "@ministryofjustice/hmpps-electronic-monitoring-components": "0.2.18-beta.1",
@@ -2162,6 +2163,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@flipt-io/flipt-client-js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@flipt-io/flipt-client-js/-/flipt-client-js-0.5.0.tgz",
+      "integrity": "sha512-7LrQUovJ+F4mnIsnVGGm/5x4/wZOsVW5gZslXlv7HjyXjFbwx/GDrnmIkJwHfzUyk2TE90IwmlYWiUg1xQVpFw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanfs/core": {
@@ -7576,6 +7589,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -9166,6 +9188,29 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -9379,6 +9424,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/formidable": {
@@ -13400,6 +13457,44 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-gyp": {
       "version": "12.1.0",
       "dev": true,
@@ -17111,6 +17206,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/web-worker": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.803.0",
+    "@flipt-io/flipt-client-js": "0.5.0",
     "@ministryofjustice/frontend": "9.0.0",
     "@ministryofjustice/hmpps-auth-clients": "^0.0.1-alpha.4",
     "@ministryofjustice/hmpps-electronic-monitoring-components": "0.2.18-beta.1",

--- a/server/app.ts
+++ b/server/app.ts
@@ -16,6 +16,7 @@ import setUpStaticResources from './middleware/setUpStaticResources'
 import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import setUpWebSecurity from './middleware/setUpWebSecurity'
 import setUpWebSession from './middleware/setUpWebSession'
+import evaluateFeatureFlags from './middleware/evaluateFeatureFlags'
 
 import routes from './routes'
 import type { Services } from './services'
@@ -49,6 +50,7 @@ export default function createApp(services: Services): express.Application {
   app.use(authorisationMiddleware())
   app.use(setUpCsrf())
   app.use(setUpCurrentUser())
+  app.use(evaluateFeatureFlags(services.flagService))
 
   app.use(
     '*',

--- a/server/config.ts
+++ b/server/config.ts
@@ -105,8 +105,10 @@ const config = {
   rateWindowMS: Number(get('RATE_WINDOW_MS', 900000)),
   rateLimitMax: Number(get('RATE_LIMIT_MAX', 100)),
   mpopUrl: get('MPOP_URL', 'https://manage-people-on-probation-dev.hmpps.service.justice.gov.uk', requiredInProduction),
-  enableHeatmap: get('ENABLE_HEATMAP', 'false') === 'true',
-  enablePingCardNavigation: get('ENABLE_PING_CARD_NAVIGATION', 'false') === 'true',
+  flipt: {
+    url: get('FLIPT_URL', 'http://localhost:8100', requiredInProduction),
+    namespace: get('FLIPT_NAMESPACE', 'hmpps-electronic-monitoring-data-insights', requiredInProduction),
+  },
 }
 
 export interface ApiConfig {

--- a/server/middleware/evaluateFeatureFlags.test.ts
+++ b/server/middleware/evaluateFeatureFlags.test.ts
@@ -1,0 +1,56 @@
+import { NextFunction, Request, Response } from 'express'
+import evaluateFeatureFlags from './evaluateFeatureFlags'
+import FlagService from '../services/flagService'
+import FeatureFlags from '../models/FeatureFlags'
+
+describe('evaluateFeatureFlags', () => {
+  it('adds evaluated flags to response locals', async () => {
+    const flags = new FeatureFlags()
+    flags.enableHeatmap = true
+    flags.enablePingCardNavigation = false
+
+    const flagService = {
+      getFlags: jest.fn().mockResolvedValue(flags),
+    } as unknown as FlagService
+    const req = {} as Request
+    const res = {
+      locals: {
+        user: {
+          username: 'USER1',
+        },
+      },
+    } as Response
+    const next = jest.fn() as NextFunction
+
+    await evaluateFeatureFlags(flagService)(req, res, next)
+
+    expect(flagService.getFlags).toHaveBeenCalledWith({ username: 'USER1' })
+    expect(res.locals.flags).toEqual(flags)
+    expect(res.locals.enableHeatmap).toEqual(true)
+    expect(res.locals.enablePingCardNavigation).toEqual(false)
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  it('defaults flags to false when Flipt fails', async () => {
+    const error = new Error('Flipt failed')
+    const flagService = {
+      getFlags: jest.fn().mockRejectedValue(error),
+    } as unknown as FlagService
+    const req = {} as Request
+    const res = {
+      locals: {
+        user: {
+          username: 'USER1',
+        },
+      },
+    } as Response
+    const next = jest.fn() as NextFunction
+
+    await evaluateFeatureFlags(flagService)(req, res, next)
+
+    expect(res.locals.flags).toEqual(new FeatureFlags())
+    expect(res.locals.enableHeatmap).toEqual(false)
+    expect(res.locals.enablePingCardNavigation).toEqual(false)
+    expect(next).toHaveBeenCalledWith()
+  })
+})

--- a/server/middleware/evaluateFeatureFlags.ts
+++ b/server/middleware/evaluateFeatureFlags.ts
@@ -1,0 +1,23 @@
+import { RequestHandler } from 'express'
+import logger from '../../logger'
+import FeatureFlags from '../models/FeatureFlags'
+import FlagService from '../services/flagService'
+
+export default function evaluateFeatureFlags(flagService: FlagService): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      const flags = await flagService.getFlags({ username: res.locals.user?.username })
+      res.locals.flags = flags
+      res.locals.enableHeatmap = flags.enableHeatmap
+      res.locals.enablePingCardNavigation = flags.enablePingCardNavigation
+      next()
+    } catch (error) {
+      logger.error(error, 'Failed to retrieve flipt feature flags')
+      const flags = new FeatureFlags()
+      res.locals.flags = flags
+      res.locals.enableHeatmap = flags.enableHeatmap
+      res.locals.enablePingCardNavigation = flags.enablePingCardNavigation
+      next()
+    }
+  }
+}

--- a/server/models/FeatureFlags.ts
+++ b/server/models/FeatureFlags.ts
@@ -1,0 +1,13 @@
+/* eslint-disable lines-between-class-members */
+export default class FeatureFlags {
+  [index: string]: boolean
+  enableHeatmap = false
+  enablePingCardNavigation = false
+}
+
+export type FeatureFlagName = 'enableHeatmap' | 'enablePingCardNavigation'
+
+export const featureFlagKeys: Record<FeatureFlagName, string> = {
+  enableHeatmap: 'enable-heatmap',
+  enablePingCardNavigation: 'enable-ping-card-navigation',
+}

--- a/server/services/flagService.test.ts
+++ b/server/services/flagService.test.ts
@@ -1,0 +1,68 @@
+import { FliptClient } from '@flipt-io/flipt-client-js'
+import FlagService from './flagService'
+
+jest.mock('@flipt-io/flipt-client-js', () => ({
+  FliptClient: {
+    init: jest.fn(),
+  },
+}))
+
+const evaluateBoolean = jest.fn()
+
+describe('FlagService', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    ;(FliptClient.init as jest.Mock).mockResolvedValue({ evaluateBoolean })
+  })
+
+  it('returns feature flags based on Flipt boolean evaluation results', async () => {
+    evaluateBoolean
+      .mockReturnValueOnce({ flagKey: 'enable-heatmap', enabled: true })
+      .mockReturnValueOnce({ flagKey: 'enable-ping-card-navigation', enabled: false })
+
+    const flags = await new FlagService().getFlags({ username: 'USER1' })
+
+    expect(FliptClient.init).toHaveBeenCalledWith({
+      namespace: 'hmpps-electronic-monitoring-data-insights',
+      url: 'http://localhost:8100',
+      updateInterval: 120,
+    })
+    expect(evaluateBoolean).toHaveBeenNthCalledWith(1, {
+      flagKey: 'enable-heatmap',
+      entityId: 'user1',
+      context: {
+        username: 'user1',
+      },
+    })
+    expect(evaluateBoolean).toHaveBeenNthCalledWith(2, {
+      flagKey: 'enable-ping-card-navigation',
+      entityId: 'user1',
+      context: {
+        username: 'user1',
+      },
+    })
+    expect(flags.enableHeatmap).toEqual(true)
+    expect(flags.enablePingCardNavigation).toEqual(false)
+  })
+
+  it('defaults a flag to false when Flipt does not return the requested flag key', async () => {
+    evaluateBoolean
+      .mockReturnValueOnce({ flagKey: 'enable-heatmap', enabled: true })
+      .mockReturnValueOnce({ flagKey: 'unexpected-flag', enabled: true })
+
+    const flags = await new FlagService().getFlags({})
+
+    expect(evaluateBoolean).toHaveBeenCalledWith({
+      flagKey: 'enable-heatmap',
+      entityId: 'anonymous',
+      context: {},
+    })
+    expect(evaluateBoolean).toHaveBeenCalledWith({
+      flagKey: 'enable-ping-card-navigation',
+      entityId: 'anonymous',
+      context: {},
+    })
+    expect(flags.enableHeatmap).toEqual(true)
+    expect(flags.enablePingCardNavigation).toEqual(false)
+  })
+})

--- a/server/services/flagService.ts
+++ b/server/services/flagService.ts
@@ -1,0 +1,38 @@
+import { FliptClient } from '@flipt-io/flipt-client-js'
+import logger from '../../logger'
+import config from '../config'
+import FeatureFlags, { featureFlagKeys } from '../models/FeatureFlags'
+
+export default class FlagService {
+  async getFlags(context: { username?: string }): Promise<FeatureFlags> {
+    const fliptClient = await FliptClient.init({
+      namespace: config.flipt.namespace,
+      url: config.flipt.url,
+      updateInterval: 120,
+    })
+
+    const featureFlags = new FeatureFlags()
+    const flagList = Object.entries(featureFlagKeys)
+    const entityId = context.username?.toLowerCase() || 'anonymous'
+    const evaluationContext = {
+      ...(context.username ? { username: context.username.toLowerCase() } : {}),
+    }
+
+    for (const [featureFlagName, flagKey] of flagList) {
+      const result = fliptClient.evaluateBoolean({
+        flagKey,
+        entityId,
+        context: evaluationContext,
+      })
+
+      if (result.flagKey === flagKey) {
+        featureFlags[featureFlagName] = result.enabled === true
+      } else {
+        logger.warn(`Expected response for flag ${flagKey}, got ${result.flagKey} - defaulting to false`)
+        featureFlags[featureFlagName] = false
+      }
+    }
+
+    return featureFlags
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -3,6 +3,7 @@ import AuditService from './auditService'
 import CaseLocationActivityService from './caseLocationActivityService'
 import DateSearchValidationService from './dateSearchValidationService'
 import EmdiService from './emdiService'
+import FlagService from './flagService'
 import LocationsService from './locationsService'
 import PeopleService from './peopleService'
 import TrailService from './trailService'
@@ -17,6 +18,7 @@ export const services = () => {
   const peopleService = new PeopleService(peopleApiClient)
   const trailService = new TrailService()
   const dateSearchValidationService = new DateSearchValidationService()
+  const flagService = new FlagService()
 
   return {
     applicationInfo,
@@ -27,6 +29,7 @@ export const services = () => {
     peopleService,
     trailService,
     dateSearchValidationService,
+    flagService,
   }
 }
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -26,8 +26,8 @@ export default function nunjucksSetup(app: express.Express): void {
   app.locals.environmentNameColour = config.environmentName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
   app.locals.common = commonLocale.en
   app.locals.mpopUrl = config.mpopUrl
-  app.locals.enableHeatmap = config.enableHeatmap
-  app.locals.enablePingCardNavigation = config.enablePingCardNavigation
+  app.locals.enableHeatmap = false
+  app.locals.enablePingCardNavigation = false
 
   let assetManifest: Record<string, string> = {}
 

--- a/server/views/pages/casesLocation.njk
+++ b/server/views/pages/casesLocation.njk
@@ -19,7 +19,7 @@
   {% include "partials/popAlert.njk" %}
   {% include "partials/casesSubNavigation.njk" %}
   <div class="location-activity">
-    <h2 class="govuk-heading-m">{{ locale.title }}</h2>
+    <h1 class="govuk-heading-m">{{ locale.title }}</h1>
     <div class="date-time-picker">
       <div class="govuk-grid-row">
         {% include "partials/mapSearchForm.njk" %}

--- a/server/views/partials/mapSearchForm.njk
+++ b/server/views/partials/mapSearchForm.njk
@@ -29,7 +29,7 @@
 
 <div class="govuk-width-container">
     <div class="govuk-grid-row govuk-!-margin-bottom-3 govuk-!-margin-right-0 govuk-!-margin-left-0">
-        <h3 class="govuk-heading-s">{{ locale.search.heading }}</h3>
+        <h2 class="govuk-heading-s">{{ locale.search.heading }}</h2>
         <div class="map-search govuk-!-padding-4">
             <form
                 id="dateFilterForm"

--- a/server/views/partials/profileInfoHeader.njk
+++ b/server/views/partials/profileInfoHeader.njk
@@ -1,5 +1,5 @@
 {%- from "moj/components/badge/macro.njk" import mojBadge -%}
-<header class="profile-info-header">
+<div class="profile-info-header" role="region" aria-label="Person details">
     {% include "../partials/profileInfo.njk" %}
     {% if showComplianceBadge %}
       {{ mojBadge({
@@ -9,4 +9,4 @@
           }) 
       }}
     {% endif %}
-</header>
+</div>


### PR DESCRIPTION
## Summary

- Fix duplicate banner landmark by changing the profile info header to a labelled region
- Add a proper `h1` and correct heading order on the location activity page
- Update accessibility test setup to stub frontend components and use stable local case navigation
- Wait for map shadow-DOM accessibility labels before running axe checks

## Testing

- `npm run build`
- `npm run typecheck`
- `npm run test:a11y`