### PR TITLE
Fix accessibility violations in case pages

### DIFF
--- a/accessibility_tests/e2e/accessibility.spec.ts
+++ b/accessibility_tests/e2e/accessibility.spec.ts
@@ -38,6 +38,7 @@ test.describe('Accessibility', () => {
     await goToCasesPage(page)
 
     await page.locator('[data-qa=cases-sub-navigation]').getByRole('link', { name: 'Location activity' }).click()
+    await page.locator('#crn').fill('X123456')
     await page.locator('#start-date').fill('01/01/2026')
     await page.locator('#start-hour').fill('10')
     await page.locator('#start-minute').fill('00')

--- a/accessibility_tests/support/accessibility.ts
+++ b/accessibility_tests/support/accessibility.ts
@@ -2,6 +2,13 @@ import { AxeBuilder } from '@axe-core/playwright'
 import { expect, type Page } from '@playwright/test'
 
 const expectNoAccessibilityViolations = async (page: Page): Promise<void> => {
+  if ((await page.locator('[data-qa=em-map]').count()) > 0) {
+    await page.waitForFunction(() => {
+      const map = document.querySelector('em-map') as HTMLElement & { shadowRoot: ShadowRoot | null }
+      return map?.shadowRoot?.querySelector('.ol-zoomslider-thumb')?.getAttribute('aria-label') === 'Adjust map zoom'
+    })
+  }
+
   const results = await new AxeBuilder({ page })
     .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'])
     .analyze()

--- a/accessibility_tests/support/setup.ts
+++ b/accessibility_tests/support/setup.ts
@@ -3,13 +3,37 @@ import { expect, type Page } from '@playwright/test'
 import auth from '../../integration_tests/mockApis/auth'
 import emdiApi from '../../integration_tests/mockApis/emdiApi'
 import locationActivity from '../../integration_tests/mockApis/locationActivity'
-import { resetStubs } from '../../integration_tests/mockApis/wiremock'
+import { resetStubs, stubFor } from '../../integration_tests/mockApis/wiremock'
 import vectorStyle from '../../integration_tests/fixtures/vectorStyle.json'
 
 export const stubCommonApis = async (): Promise<void> => {
   await resetStubs()
   await auth.stubSignIn()
   await emdiApi.stubExampleTime()
+  await stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/components/api/components.*',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: {
+        header: {
+          html: '<header class="probation-common-header govuk-!-display-none-print" role="banner"><a class="probation-common-header__link" href="/">HMPPS</a></header>',
+          css: [],
+          javascript: [],
+        },
+        footer: {
+          html: '<footer class="govuk-footer" role="contentinfo"></footer>',
+          css: [],
+          javascript: [],
+        },
+      },
+    },
+  })
 }
 
 export const signIn = async (page: Page): Promise<void> => {
@@ -21,7 +45,7 @@ export const signIn = async (page: Page): Promise<void> => {
 }
 
 export const goToCasesPage = async (page: Page): Promise<void> => {
-  await page.locator('[data-qa=primary-navigation]').getByRole('link', { name: 'Cases' }).click()
+  await page.goto('/cases/1/overview')
   await expect(page.getByRole('heading', { name: 'Adam Collins' })).toBeVisible()
 }
 

--- a/integration_tests/pages/locationActivity.ts
+++ b/integration_tests/pages/locationActivity.ts
@@ -7,7 +7,7 @@ export default class LocationActivityPage extends Page {
   }
 
   checkOnPage(): void {
-    cy.get('h2').contains(this.title)
+    cy.get('h1').contains(this.title)
   }
 
   dateSearchForm = (): PageElement => cy.get('[data-qa=date-filter-form]')

--- a/server/views/pages/casesLocation.njk
+++ b/server/views/pages/casesLocation.njk
@@ -19,7 +19,7 @@
   {% include "partials/popAlert.njk" %}
   {% include "partials/casesSubNavigation.njk" %}
   <div class="location-activity">
-    <h2 class="govuk-heading-m">{{ locale.title }}</h2>
+    <h1 class="govuk-heading-m">{{ locale.title }}</h1>
     <div class="date-time-picker">
       <div class="govuk-grid-row">
         {% include "partials/mapSearchForm.njk" %}

--- a/server/views/partials/mapSearchForm.njk
+++ b/server/views/partials/mapSearchForm.njk
@@ -29,7 +29,7 @@
 
 <div class="govuk-width-container">
     <div class="govuk-grid-row govuk-!-margin-bottom-3 govuk-!-margin-right-0 govuk-!-margin-left-0">
-        <h3 class="govuk-heading-s">{{ locale.search.heading }}</h3>
+        <h2 class="govuk-heading-s">{{ locale.search.heading }}</h2>
         <div class="map-search govuk-!-padding-4">
             <form
                 id="dateFilterForm"

--- a/server/views/partials/profileInfoHeader.njk
+++ b/server/views/partials/profileInfoHeader.njk
@@ -1,5 +1,5 @@
 {%- from "moj/components/badge/macro.njk" import mojBadge -%}
-<header class="profile-info-header">
+<div class="profile-info-header" role="region" aria-label="Person details">
     {% include "../partials/profileInfo.njk" %}
     {% if showComplianceBadge %}
       {{ mojBadge({
@@ -9,4 +9,4 @@
           }) 
       }}
     {% endif %}
-</header>
+</div>


### PR DESCRIPTION
## Summary

- Fix duplicate banner landmark by changing the profile info header to a labelled region
- Add a proper `h1` and correct heading order on the location activity page
- Update accessibility test setup to stub frontend components and use stable local case navigation
- Wait for map shadow-DOM accessibility labels before running axe checks

## Testing

- `npm run build`
- `npm run typecheck`
- `npm run test:a11y`