### PR TITLE
chore: Update Docker base image to HMPPS Node 24 Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:22-alpine AS base
+FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine AS base
 
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@ministryofjustice/hmpps-electronic-monitoring-components": "0.2.18-beta.1",
         "@ministryofjustice/hmpps-monitoring": "^0.0.1-beta.2",
         "@ministryofjustice/hmpps-probation-frontend-components": "^1.0.0",
-        "@ministryofjustice/hmpps-rest-client": "^2.1.0",
+        "@ministryofjustice/hmpps-rest-client": "2.2.0",
         "@testing-library/jest-dom": "6.9.1",
         "agentkeepalive": "^4.6.0",
         "applicationinsights": "^2.9.6",
@@ -3183,35 +3183,6 @@
         "node": "22 || 24 || 26"
       }
     },
-    "node_modules/@ministryofjustice/hmpps-auth-clients/node_modules/@ministryofjustice/hmpps-rest-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-rest-client/-/hmpps-rest-client-2.1.0.tgz",
-      "integrity": "sha512-Lx2UTbVyVADZees2ikGtpvkErPCLCptr0qCYVQBQ8a2CEUegWXkQ/U6Ia+WiCGODs3CstROGPak7DugWtlm29w==",
-      "license": "MIT",
-      "dependencies": {
-        "agentkeepalive": "^4.6.0",
-        "superagent": "^10.3.0"
-      },
-      "engines": {
-        "node": "22 || 24 || 26"
-      }
-    },
-    "node_modules/@ministryofjustice/hmpps-auth-clients/node_modules/@ministryofjustice/hmpps-rest-client": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-rest-client/-/hmpps-rest-client-0.0.1.tgz",
-      "integrity": "sha512-msTioV66R3ErO8YGWfBvv8uKAYfmYcAVzvvt3RiXMbmW7oqKDihKpt6fhmH+x6Ytxbs+kQYwjVx2/RsxEf9Ecw==",
-      "license": "MIT",
-      "dependencies": {
-        "agentkeepalive": "^4.6.0",
-        "superagent": "^10.2.1"
-      },
-      "bin": {
-        "hmpps-rest-client": "bin/migrate.sh"
-      },
-      "engines": {
-        "node": "20 || 22"
-      }
-    },
     "node_modules/@ministryofjustice/hmpps-electronic-monitoring-components": {
       "version": "0.2.18-beta.1",
       "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-electronic-monitoring-components/-/hmpps-electronic-monitoring-components-0.2.18-beta.1.tgz",
@@ -3320,9 +3291,9 @@
       "license": "MIT"
     },
     "node_modules/@ministryofjustice/hmpps-rest-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-rest-client/-/hmpps-rest-client-2.1.0.tgz",
-      "integrity": "sha512-Lx2UTbVyVADZees2ikGtpvkErPCLCptr0qCYVQBQ8a2CEUegWXkQ/U6Ia+WiCGODs3CstROGPak7DugWtlm29w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-rest-client/-/hmpps-rest-client-2.2.0.tgz",
+      "integrity": "sha512-sZQ6K47NvtcE4trUGRS85JqVRpBHAteuC8XT0N5qB14TLniNJVvRVoCK6O/gGwT9wQEzLW7C6DW1T6SOFGnTrQ==",
       "license": "MIT",
       "dependencies": {
         "agentkeepalive": "^4.6.0",
@@ -9425,6 +9396,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@ministryofjustice/hmpps-electronic-monitoring-components": "0.2.18-beta.1",
     "@ministryofjustice/hmpps-monitoring": "^0.0.1-beta.2",
     "@ministryofjustice/hmpps-probation-frontend-components": "^1.0.0",
-    "@ministryofjustice/hmpps-rest-client": "^2.1.0",
+    "@ministryofjustice/hmpps-rest-client": "2.2.0",
     "@testing-library/jest-dom": "6.9.1",
     "agentkeepalive": "^4.6.0",
     "applicationinsights": "^2.9.6",


### PR DESCRIPTION
## Summary

- Updates the Docker base image from `node:22-alpine` to `ghcr.io/ministryofjustice/hmpps-node:24-alpine`.
- Leaves the rest of the Dockerfile unchanged.
