### PR TITLE
fix: dockerfile

### DIFF
--- a/.allowed-scripts.mjs
+++ b/.allowed-scripts.mjs
@@ -3,10 +3,11 @@ import { configureAllowedScripts } from '@ministryofjustice/hmpps-npm-script-all
 export default configureAllowedScripts({
   allowlist: {
     'node_modules/@parcel/watcher@2.5.1': 'ALLOW',
-    'node_modules/cypress@14.3.2': 'ALLOW',
+    'node_modules/cypress@15.17.0': 'ALLOW',
     'node_modules/dtrace-provider@0.8.8': 'ALLOW',
-    'node_modules/esbuild@0.25.4': 'ALLOW',
+    'node_modules/esbuild@0.28.1': 'ALLOW',
     'node_modules/fsevents@2.3.3': 'ALLOW',
-    'node_modules/unrs-resolver@1.7.2': 'ALLOW',
+    'node_modules/playwright/node_modules/fsevents@2.3.2': 'ALLOW',
+    'node_modules/unrs-resolver@1.12.2': 'ALLOW',
   },
 })

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ README.md
 node_modules
 npm-debug.log
 .*
+!.allowed-scripts.mjs
+!.npmrc
 **/*.test.js
 scss-report.txt
 eslint-report.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,10 @@
-# Stage: base image
-FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine AS base
+# Build args available to all stages
+ARG BUILD_NUMBER
+ARG GIT_REF
+ARG GIT_BRANCH
 
-LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
-
-RUN apk --update-cache upgrade --available \
-  && apk --no-cache add tzdata \
-  && rm -rf /var/cache/apk/*
-
-ENV TZ=Europe/London
-RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone
-
-RUN addgroup --gid 2000 --system appgroup && \
-    adduser --uid 2000 --system appuser --ingroup appgroup
-
-WORKDIR /app
+# Stage: build assets
+FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine AS build
 
 ARG BUILD_NUMBER
 ARG GIT_REF
@@ -24,29 +15,23 @@ RUN test -n "$BUILD_NUMBER" || (echo "BUILD_NUMBER not set" && false)
 RUN test -n "$GIT_REF" || (echo "GIT_REF not set" && false)
 RUN test -n "$GIT_BRANCH" || (echo "GIT_BRANCH not set" && false)
 
-# Define env variables for runtime health / info
-ENV BUILD_NUMBER=${BUILD_NUMBER}
-ENV GIT_REF=${GIT_REF}
-ENV GIT_BRANCH=${GIT_BRANCH}
+WORKDIR /app
 
-# Stage: build assets
-FROM base AS build
-
-ARG BUILD_NUMBER
-ARG GIT_REF
-ARG GIT_BRANCH
-
-COPY package*.json ./
-RUN CYPRESS_INSTALL_BINARY=0 npm run setup --no-audit
+COPY package*.json .allowed-scripts.mjs .npmrc ./
+RUN CYPRESS_INSTALL_BINARY=0 NPM_CONFIG_AUDIT=false NPM_CONFIG_FUND=false npm run setup
 ENV NODE_ENV='production'
 
 COPY . .
 RUN npm run build
 
-RUN npm prune --no-audit --omit=dev
+RUN npm prune --no-audit --no-fund --omit=dev
 
 # Stage: copy production assets and dependencies
-FROM base
+FROM ghcr.io/ministryofjustice/hmpps-node:24-alpine-runtime
+
+ARG BUILD_NUMBER
+ARG GIT_REF
+ARG GIT_BRANCH
 
 COPY --from=build --chown=appuser:appgroup \
         /app/package.json \
@@ -60,7 +45,10 @@ COPY --from=build --chown=appuser:appgroup \
         /app/node_modules ./node_modules
 
 EXPOSE 3000
+ENV BUILD_NUMBER=${BUILD_NUMBER}
+ENV GIT_REF=${GIT_REF}
+ENV GIT_BRANCH=${GIT_BRANCH}
 ENV NODE_ENV='production'
 USER 2000
 
-CMD [ "npm", "start" ]
+CMD [ "node", "dist/server.js" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ministryofjustice/frontend": "9.0.0",
         "@ministryofjustice/hmpps-auth-clients": "^3.0.0",
         "@ministryofjustice/hmpps-electronic-monitoring-components": "0.2.18-beta.1",
-        "@ministryofjustice/hmpps-monitoring": "^0.0.1-beta.2",
+        "@ministryofjustice/hmpps-monitoring": "2.1.0",
         "@ministryofjustice/hmpps-probation-frontend-components": "^1.0.0",
         "@ministryofjustice/hmpps-rest-client": "2.2.0",
         "@testing-library/jest-dom": "6.9.1",
@@ -96,7 +96,7 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": "^22",
+        "node": "^22 || ^24",
         "npm": "^10 || ^11"
       }
     },
@@ -3268,17 +3268,21 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-monitoring": {
-      "version": "0.0.1-beta.2",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-monitoring/-/hmpps-monitoring-2.1.0.tgz",
+      "integrity": "sha512-IL813DPaJCIeT7yjSFDGe6TJnuA2UJnREyhAFJyXOl9+wPFdTxdmlDwJyRt/RoGdohw0q7z2wMDXua/VOhsW4w==",
       "license": "MIT",
+      "dependencies": {
+        "@ministryofjustice/hmpps-rest-client": "^2.1.0"
+      },
       "bin": {
         "hmpps-monitoring": "bin/migrate.sh"
       },
       "engines": {
-        "node": "20 || 22"
+        "node": "22 || 24 || 26"
       },
       "peerDependencies": {
-        "agentkeepalive": "4.x",
-        "superagent": "^10.x"
+        "agentkeepalive": "4.x"
       }
     },
     "node_modules/@ministryofjustice/hmpps-npm-script-allowlist": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "setup": "npm ci && hmpps-npm-script-run-allowlist"
   },
   "engines": {
-    "node": "^22",
+    "node": "^22 || ^24",
     "npm": "^10 || ^11"
   },
   "jest": {
@@ -88,7 +88,7 @@
     "@ministryofjustice/frontend": "9.0.0",
     "@ministryofjustice/hmpps-auth-clients": "^3.0.0",
     "@ministryofjustice/hmpps-electronic-monitoring-components": "0.2.18-beta.1",
-    "@ministryofjustice/hmpps-monitoring": "^0.0.1-beta.2",
+    "@ministryofjustice/hmpps-monitoring": "2.1.0",
     "@ministryofjustice/hmpps-probation-frontend-components": "^1.0.0",
     "@ministryofjustice/hmpps-rest-client": "2.2.0",
     "@testing-library/jest-dom": "6.9.1",


### PR DESCRIPTION
### Summary

- Updated the Dockerfile to match the HMPPS hmpps-node base image pattern, using separate 24-alpine build and 24-alpine-runtime runtime stages.
- Removed duplicate appuser/appgroup creation, fixing the pipeline failure where the base image already contained appgroup.
- Included .allowed-scripts.mjs and .npmrc in the Docker build context so npm run setup works inside the image.
- Updated the npm script allowlist to match the current lockfile dependency versions.
- Updated Node engine support to allow Node 24 and upgraded @ministryofjustice/hmpps-monitoring to a version compatible with Node 24.

### Testing

- npm run build
- npm run typecheck
- npx hmpps-npm-script-run-allowlist

Note: local Docker build progressed past the original appgroup error and Node engine errors, but was stopped after npm ci stayed silent for several minutes inside the Docker install layer.