### PR TITLE
feat: Add primary header phase banner with tests

### DIFF
--- a/integration_tests/e2e/layout.cy.ts
+++ b/integration_tests/e2e/layout.cy.ts
@@ -25,6 +25,23 @@ context('Layout', () => {
     indexPage.fallbackFooter().should('exist')
   })
 
+  it('Displays the service phase banner', () => {
+    cy.signIn()
+    const indexPage = Page.verifyOnPage(IndexPage)
+
+    indexPage.servicePhaseBanner().should('contain.text', 'Beta')
+    indexPage.servicePhaseBanner().should('contain.text', 'This is a new service.')
+    indexPage
+      .servicePhaseBanner()
+      .contains('a', 'Give feedback (opens in a new tab)')
+      .should('have.attr', 'href', 'https://www.smartsurvey.co.uk/t/CF3MFT/')
+      .and('have.attr', 'target', '_blank')
+    indexPage
+      .servicePhaseBanner()
+      .contains('a', 'report a problem')
+      .should('have.attr', 'href', 'mailto:emdisupport@justice.gov.uk?subject=EMDI problem')
+  })
+
   it('Should display the PoP info header labels and values', () => {
     cy.signIn()
     const indexPage = Page.verifyOnPage(IndexPage)

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -9,6 +9,8 @@ export default class IndexPage extends Page {
 
   headerPhaseBanner = (): PageElement => cy.get('[data-qa=header-phase-banner]')
 
+  servicePhaseBanner = (): PageElement => cy.get('[data-qa=service-phase-banner]')
+
   // The data-qa attribute is not avaialable in the 3rd party header and footer
   fallbackHeader = (): PageElement => cy.get('.probation-common-fallback-header')
 

--- a/server/views/partials/primaryHeader.njk
+++ b/server/views/partials/primaryHeader.njk
@@ -1,4 +1,15 @@
 {%- from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation -%}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
+{{ govukPhaseBanner({
+  tag: {
+    text: "Beta"
+  },
+  html: 'This is a new service. <a href="https://www.smartsurvey.co.uk/t/CF3MFT/" target="_blank">Give feedback (opens in a new tab)</a> to help us improve it, <a class="govuk-link" href="mailto:emdisupport@justice.gov.uk?subject=EMDI problem">report a problem</a>.',
+  attributes: {
+    "data-qa": "service-phase-banner"
+  }
+}) }}
 
 {% set items = [
   {

--- a/server/views/partials/primaryHeader.test.ts
+++ b/server/views/partials/primaryHeader.test.ts
@@ -1,0 +1,43 @@
+import express from 'express'
+import nunjucksSetup from '../../utils/nunjucksSetup'
+
+const renderPrimaryHeader = async (activeNav?: string): Promise<string> => {
+  const app = express()
+  nunjucksSetup(app)
+
+  return new Promise((resolve, reject) => {
+    app.render('partials/primaryHeader', { activeNav }, (error, html) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve(html)
+    })
+  })
+}
+
+describe('primaryHeader template', () => {
+  it('renders the service phase banner with feedback and support links', async () => {
+    const html = await renderPrimaryHeader()
+
+    expect(html).toContain('data-qa="service-phase-banner"')
+    expect(html).toMatch(/<strong class="govuk-tag govuk-phase-banner__content__tag">\s*Beta\s*<\/strong>/)
+    expect(html).toContain('This is a new service.')
+    expect(html).toContain('href="https://www.smartsurvey.co.uk/t/CF3MFT/"')
+    expect(html).toContain('target="_blank"')
+    expect(html).toContain('Give feedback (opens in a new tab)')
+    expect(html).toContain('href="mailto:emdisupport@justice.gov.uk?subject=EMDI problem"')
+    expect(html).toContain('report a problem')
+  })
+
+  it('renders the primary navigation alongside the phase banner', async () => {
+    const html = await renderPrimaryHeader('cases')
+
+    expect(html).toContain('data-qa="primary-navigation"')
+    expect(html).toContain('aria-label="Primary navigation"')
+    expect(html).toContain('href="https://manage-people-on-probation-dev.hmpps.service.justice.gov.uk/case"')
+    expect(html).toContain('aria-current="page"')
+    expect(html).toContain('Cases')
+  })
+})


### PR DESCRIPTION
## Summary

- add a GOV.UK Beta phase banner to the primary header
- include feedback and report-a-problem links in the banner
- add a stable `data-qa` selector for the new service phase banner
- add Nunjucks template coverage for the banner content, links, and primary navigation
- add Cypress layout coverage to verify the banner appears in the signed-in page flow

## Testing

- `npm run build`
- `npm test -- --runInBand server/views/partials/primaryHeader.test.ts`
- `npm test -- --runInBand`
- `npm run lint`
- `npx cypress run --config video=false --spec integration_tests/e2e/layout.cy.ts`