### PR TITLE
fix: Remove scaffold content from homepage

### DIFF
--- a/accessibility_tests/support/setup.ts
+++ b/accessibility_tests/support/setup.ts
@@ -41,7 +41,8 @@ export const signIn = async (page: Page): Promise<void> => {
   const signInUrl = await auth.getSignInUrl()
 
   await page.goto(signInUrl)
-  await expect(page.getByRole('heading', { name: 'This site is under construction...' })).toBeVisible()
+  await expect(page).toHaveURL(/\/$/)
+  await expect(page).toHaveTitle(/Home/)
 }
 
 export const goToCasesPage = async (page: Page): Promise<void> => {

--- a/integration_tests/e2e/layout.cy.ts
+++ b/integration_tests/e2e/layout.cy.ts
@@ -2,11 +2,6 @@ import IndexPage from '../pages/index'
 import Page from '../pages/page'
 
 context('Layout', () => {
-  const profileDetails = [
-    { label: 'CRN:', value: 'X172591' },
-    { label: 'Date of birth:', value: '7 October 1964' },
-  ]
-
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
@@ -42,9 +37,10 @@ context('Layout', () => {
       .should('have.attr', 'href', 'mailto:emdisupport@justice.gov.uk?subject=EMDI problem')
   })
 
-  it('Should display the PoP info header labels and values', () => {
+  it('Does not display scaffold PoP details on the home page', () => {
     cy.signIn()
     const indexPage = Page.verifyOnPage(IndexPage)
-    indexPage.verifyProfileDetails(profileDetails)
+    indexPage.profileInfoHeader().should('not.exist')
+    cy.contains('Richard Marks').should('not.exist')
   })
 })

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -2,7 +2,12 @@ import Page, { PageElement } from './page'
 
 export default class IndexPage extends Page {
   constructor() {
-    super('This site is under construction...')
+    super('')
+  }
+
+  checkOnPage(): void {
+    cy.location('pathname').should('eq', '/')
+    cy.title().should('contain', 'Home')
   }
 
   headerUserName = (): PageElement => cy.get('[data-qa=header-user-name]')
@@ -17,12 +22,4 @@ export default class IndexPage extends Page {
   fallbackFooter = (): PageElement => cy.get('.probation-common-fallback-footer')
 
   profileInfoHeader = (): PageElement => cy.get('[data-qa=profile-info-header__subject-details]')
-
-  verifyProfileDetails(details) {
-    this.profileInfoHeader().within(() => {
-      details.forEach(item => {
-        cy.contains('li', item.label).should('contain.text', item.value)
-      })
-    })
-  }
 }

--- a/server/controllers/home/homeController.test.ts
+++ b/server/controllers/home/homeController.test.ts
@@ -2,7 +2,6 @@ import { Request, Response } from 'express'
 import HomeController from './homeController'
 import AuditService, { Page } from '../../services/auditService'
 import { user } from '../../routes/testutils/appSetup'
-import mockPopDetails from '../mocks/popDetails'
 
 jest.mock('../../services/auditService')
 
@@ -35,9 +34,6 @@ describe('HomeController', () => {
       })
       expect(res.render).toHaveBeenCalledWith('pages/index', {
         activeNav: '/',
-        popData: mockPopDetails,
-        showComplianceBadge: true,
-        alert: true,
       })
     })
   })

--- a/server/controllers/home/homeController.ts
+++ b/server/controllers/home/homeController.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express'
 import AuditService, { Page } from '../../services/auditService'
-import mockPopDetails from '../mocks/popDetails'
 
 export default class HomeController {
   constructor(private readonly auditService: AuditService) {}
@@ -12,11 +11,6 @@ export default class HomeController {
     })
     res.render('pages/index', {
       activeNav: '/',
-      popData: mockPopDetails,
-      showComplianceBadge: true,
-      alert: true,
-      cspNonce: res.locals.cspNonce,
-      apiKey: process.env.OS_MAPS_API_KEY,
     })
   }
 }

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -38,7 +38,9 @@ describe('GET /', () => {
       .expect('Content-Type', /html/)
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('This site is under construction...')
+        expect(res.text).toContain('HMPPS Electronic Monitoring Data Insights Ui - Home')
+        expect(res.text).not.toContain('This site is under construction...')
+        expect(res.text).not.toContain('Richard Marks')
         expect(auditService.logPageView).toHaveBeenCalledWith(Page.HOME_PAGE, {
           who: user.username,
           correlationId: expect.any(String),

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -4,21 +4,6 @@
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body" %}
 
-{% block beforeContent %}
-  {% if popData %}
-     {% include "../partials/profileInfoHeader.njk" %}
-  {% endif %}
-{% endblock %}
-
 {% block content %}
-  <h1>Richard Marks</h1>
-  {% include "partials/popAlert.njk" %}
-  <h1>This site is under construction... </h1>
-  <p>Please check back later when there is content to view.</p>
+  <h1 class="govuk-visually-hidden">{{ applicationName }}</h1>
 {% endblock %}
-
-
-
-
-
-

--- a/server/views/pages/personLocation.njk
+++ b/server/views/pages/personLocation.njk
@@ -10,7 +10,7 @@
     items: [
       {
         text: "Cases",
-        href: mpopUrl + "/cases"
+        href: mpopUrl + "/case"
       },
       {
         text: fullName,

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -26,7 +26,9 @@
   <script type="module" src="{{ '/assets/js/index.js' | assetMap }}"></script>
   <script nonce="{{ cspNonce }}">
     document.addEventListener('DOMContentLoaded', function () {
-      document.initialiseTelemetry('{{ applicationInsightsConnectionString }}', '{{ applicationInsightsRoleName }}', '{{ user.username }}')
+      if (typeof document.initialiseTelemetry === 'function') {
+        document.initialiseTelemetry('{{ applicationInsightsConnectionString }}', '{{ applicationInsightsRoleName }}', '{{ user.username }}')
+      }
     })
   </script>
 {% endblock %}

--- a/server/views/partials/primaryHeader.njk
+++ b/server/views/partials/primaryHeader.njk
@@ -1,15 +1,17 @@
 {%- from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation -%}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
-{{ govukPhaseBanner({
-  tag: {
-    text: "Beta"
-  },
-  html: 'This is a new service. <a href="https://www.smartsurvey.co.uk/t/CF3MFT/" target="_blank">Give feedback (opens in a new tab)</a> to help us improve it, <a class="govuk-link" href="mailto:emdisupport@justice.gov.uk?subject=EMDI problem">report a problem</a>.',
-  attributes: {
-    "data-qa": "service-phase-banner"
-  }
-}) }}
+<div role="region" aria-label="Service information">
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service. <a href="https://www.smartsurvey.co.uk/t/CF3MFT/" target="_blank">Give feedback (opens in a new tab)</a> to help us improve it, <a class="govuk-link" href="mailto:emdisupport@justice.gov.uk?subject=EMDI problem">report a problem</a>.',
+    attributes: {
+      "data-qa": "service-phase-banner"
+    }
+  }) }}
+</div>
 
 {% set items = [
   {


### PR DESCRIPTION
## Summary

- Remove scaffold PoP data, alert, and placeholder copy from the homepage
- Keep the homepage visually blank while preserving an accessible hidden H1
- Update homepage, layout, sign-in, and accessibility tests to no longer depend on scaffold content
- Guard telemetry initialization and wrap the service phase banner in a landmark for accessibility

## Testing

- `npm test -- --runInBand`
- `npm run typecheck`
- `npm run lint`
- `npm run test:a11y`
- `env -u ELECTRON_RUN_AS_NODE npx cypress run --config video=false`